### PR TITLE
Couples display correction

### DIFF
--- a/lib/Hea/Data.pm
+++ b/lib/Hea/Data.pm
@@ -86,6 +86,7 @@ sub library_stats {
     my $query = "
         SELECT $type as name, COUNT(*) AS value
         FROM library
+        WHERE $type <> ''
         GROUP BY $type
     ";
 

--- a/public/javascripts/hea.js
+++ b/public/javascripts/hea.js
@@ -40,7 +40,7 @@ function build_barchart (params) {
     .append('svg')
     .attr('class', 'chart')
     .attr('width', left_width + width + 40)
-    .attr('height', (bar_height) * variables.length + 30)
+    .attr('height', (yRangeBand) * variables.length + 30)
     .append("g")
     .attr("transform", "translate(-10, 20)");
  


### PR DESCRIPTION
Don't display empty 'Country' and 'Type' lines.
Avoid box being too short to display all information.